### PR TITLE
AP-8258 - Fix duplicate orders and numerous other issues

### DIFF
--- a/Block/Widget/Button/Toolbar.php
+++ b/Block/Widget/Button/Toolbar.php
@@ -25,7 +25,7 @@ class Toolbar
         }
         $order = $context->getOrder();
         // Only change the toolbar if it's an apruve order
-        if($order->getPayment()->getMethod() != 'apruve') {
+        if ($order->getPayment()->getMethod() != 'apruve') {
             return [$context, $buttonList];
         }
         

--- a/Controller/updateOrderStatus/CSRFAwareAction.php
+++ b/Controller/updateOrderStatus/CSRFAwareAction.php
@@ -20,7 +20,7 @@ function shouldApplyCSRFPatch()
 }
 
 if (shouldApplyCSRFPatch()) {
-    class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
+    abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
     {
         public function createCsrfValidationException(RequestInterface $request)
         {
@@ -33,5 +33,5 @@ if (shouldApplyCSRFPatch()) {
         }
     }
 } else {
-    class CSRFAwareAction extends \Magento\Framework\App\Action\Action { }
+    abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action { }
 }

--- a/Controller/updateOrderStatus/CSRFAwareAction.php
+++ b/Controller/updateOrderStatus/CSRFAwareAction.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Magento 2.3 requires that post actions tell it that they want to handle CSRF themselves, but this is incompatible with
- * Magneto 2.2 or earlier. To fix this, we dynamically provide two different action base classes depending on the version
+ * Magneto 2.2 or earlier. To fix this, we provide different versions of this class based on the version
  * of Magento.
  *
  * See https://magento.stackexchange.com/a/255082
@@ -9,31 +9,15 @@
 
 namespace Apruve\Payment\Controller\updateOrderStatus;
 
-function shouldApplyCSRFPatch()
+abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements \Magento\Framework\App\CsrfAwareActionInterface
 {
-    $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-    $productMetadata = $objectManager->get('Magento\Framework\App\ProductMetadataInterface');
-    $version = $productMetadata->getVersion();
-    preg_match('/2\.(\d)/', $version, $matches); // Try to extract the magento version
-    $minor_version_string = $matches[1];
-    return ((int) $minor_version_string) >= 3;
-}
-
-if (shouldApplyCSRFPatch()) {
-    abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements \Magento\Framework\App\CsrfAwareActionInterface
+    public function createCsrfValidationException(\Magento\Framework\App\RequestInterface $request): ?\Magento\Framework\App\Request\InvalidRequestException
     {
-        public function createCsrfValidationException(\Magento\Framework\App\RequestInterface $request): ?\Magento\Framework\App\Request\InvalidRequestException
-        {
-            return null;
-        }
-
-        public function validateForCsrf(\Magento\Framework\App\RequestInterface $request): ?bool
-        {
-            return true;
-        }
+        return null;
     }
-} else {
-    abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action
+
+    public function validateForCsrf(\Magento\Framework\App\RequestInterface $request): ?bool
     {
+        return true;
     }
 }

--- a/Controller/updateOrderStatus/CSRFAwareAction.php
+++ b/Controller/updateOrderStatus/CSRFAwareAction.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Magento 2.3 requires that post actions tell it that they want to handle CSRF themselves, but this is incompatible with
+ * Magneto 2.2 or earlier. To fix this, we dynamically provide two different action base classes depending on the version
+ * of Magento.
+ *
+ * See https://magento.stackexchange.com/a/255082
+ */
+
+namespace Apruve\Payment\Controller\updateOrderStatus;
+
+function shouldApplyCSRFPatch()
+{
+    $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+    $productMetadata = $objectManager->get('Magento\Framework\App\ProductMetadataInterface');
+    $version = $productMetadata->getVersion();
+    preg_match('/2\.(\d)/', $version, $matches); // Try to extract the magento version
+    $minor_version_string = $matches[1];
+    return ((int) $minor_version_string) >= 3;
+}
+
+if (shouldApplyCSRFPatch()) {
+    class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
+    {
+        public function createCsrfValidationException(RequestInterface $request)
+        {
+            return null;
+        }
+
+        public function validateForCsrf(RequestInterface $request)
+        {
+            return true;
+        }
+    }
+} else {
+    class CSRFAwareAction extends \Magento\Framework\App\Action\Action { }
+}

--- a/Controller/updateOrderStatus/CSRFAwareAction.php
+++ b/Controller/updateOrderStatus/CSRFAwareAction.php
@@ -22,12 +22,12 @@ function shouldApplyCSRFPatch()
 if (shouldApplyCSRFPatch()) {
     abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements \Magento\Framework\App\CsrfAwareActionInterface
     {
-        public function createCsrfValidationException(Magento\Framework\App\RequestInterface $request): ?Magento\Framework\App\Request\InvalidRequestException
+        public function createCsrfValidationException(\Magento\Framework\App\RequestInterface $request): ?\Magento\Framework\App\Request\InvalidRequestException
         {
             return null;
         }
 
-        public function validateForCsrf(Magento\Framework\App\RequestInterface $request): ?bool
+        public function validateForCsrf(\Magento\Framework\App\RequestInterface $request): ?bool
         {
             return true;
         }

--- a/Controller/updateOrderStatus/CSRFAwareAction.php
+++ b/Controller/updateOrderStatus/CSRFAwareAction.php
@@ -22,12 +22,12 @@ function shouldApplyCSRFPatch()
 if (shouldApplyCSRFPatch()) {
     abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements \Magento\Framework\App\CsrfAwareActionInterface
     {
-        public function createCsrfValidationException(RequestInterface $request)
+        public function createCsrfValidationException(Magento\Framework\App\RequestInterface $request): ?Magento\Framework\App\Request\InvalidRequestException
         {
             return null;
         }
 
-        public function validateForCsrf(RequestInterface $request)
+        public function validateForCsrf(Magento\Framework\App\RequestInterface $request): ?bool
         {
             return true;
         }

--- a/Controller/updateOrderStatus/CSRFAwareAction.php
+++ b/Controller/updateOrderStatus/CSRFAwareAction.php
@@ -20,7 +20,7 @@ function shouldApplyCSRFPatch()
 }
 
 if (shouldApplyCSRFPatch()) {
-    abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
+    abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action implements \Magento\Framework\App\CsrfAwareActionInterface
     {
         public function createCsrfValidationException(RequestInterface $request)
         {

--- a/Controller/updateOrderStatus/CSRFAwareAction.php
+++ b/Controller/updateOrderStatus/CSRFAwareAction.php
@@ -33,5 +33,7 @@ if (shouldApplyCSRFPatch()) {
         }
     }
 } else {
-    abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action { }
+    abstract class CSRFAwareAction extends \Magento\Framework\App\Action\Action
+    {
+    }
 }

--- a/Controller/updateOrderStatus/Index.php
+++ b/Controller/updateOrderStatus/Index.php
@@ -134,7 +134,7 @@ class Index extends CSRFAwareAction
             $apruve_invoice_uuid = $data->entity->id;
             $apruve_invoice = $this->helper->runApruveGetRequest($data->entity->links->self); // Get a full invoice
             $magento_invoice_increment_id = $apruve_invoice->merchant_invoice_id;
-            if($magento_invoice_increment_id == null) {
+            if ($magento_invoice_increment_id == null) {
                 $this->_logger->debug("Null magento invoice id returned for apruve invoice $apruve_invoice_uuid. No way to find it in magento");
                 return false;
             }
@@ -162,7 +162,6 @@ class Index extends CSRFAwareAction
                 $this->_logger->debug("ERROR: Invoice $magento_invoice_increment_id cannot be captured in response to apruve funding webhook");
             }
             return $this->transaction->addObject($this->invoice)->save();
-
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
             $this->_logger->debug("Cannot find this entity in Magento2 - possible duplicate webhook - invoiceFunded - TransactionId: {$transactionId}");
         } catch (\Exception $e) {

--- a/Controller/updateOrderStatus/Index.php
+++ b/Controller/updateOrderStatus/Index.php
@@ -184,12 +184,14 @@ class Index extends \Magento\Framework\App\Action\Action
 
     protected function _paymentTermAccepted($data)
     {
-        $apruve_order_token = $data->entity->id;
-        $magento_order_increment_id = $data->entity->merchant_order_id;
+        $apruve_order_token = $data->entity->purchase_order_id;
+        // Apruve doesn't send back our id for some reason
+        $apruve_order = $this->helper->runApruveGetRequest($data->entity->links->order);
+        $magento_order_increment_id = $apruve_order->merchant_order_id;
         $this->_logger->debug("apruve_paymentTermAccepted webhook called for apruve order $apruve_order_token with magento increment $magento_order_increment_id");
 
         try {
-            $this->order->loadByIncrementId($data->entity->merchant_order_id);
+            $this->order->loadByIncrementId($magento_order_increment_id);
             if ($this->order->getEntityId() == null) {
                 $this->_logger->debug("Cannot find this entity in Magento2 - possible duplicate webhook - paymentTermAccepted - MerchantOrderId: {$data->entity->merchant_order_id}");
                 return true; // Quietly die and return a 200 code

--- a/Controller/updateOrderStatus/Index.php
+++ b/Controller/updateOrderStatus/Index.php
@@ -44,34 +44,40 @@ class Index extends \Magento\Framework\App\Action\Action
 
     public function execute()
     {
-        if (! $this->_validate()) {
-            return;
-        };
+        $this->_logger->debug("Got a webhook");
+        try {
+            if (! $this->_validate()) {
+                return;
+            };
 
-        $data   = $this->_getData();
-        $action = $data->event;
-        $success = false;
+            $data   = $this->_getData();
+            $action = $data->event;
+            $success = false;
 
-        switch ($action) {
-            case 'invoice.closed':
-            case 'invoice.funded':
-                $success = $this->_invoiceFunded($data);
-                break;
-            // cancelled is used in docs, canceled live
-            case 'order.canceled':
-            case 'order.cancelled':
-                $success = $this->_cancelOrder($data);
-                break;
+            switch ($action) {
+                case 'invoice.closed':
+                case 'invoice.funded':
+                    $success = $this->_invoiceFunded($data);
+                    break;
+                // cancelled is used in docs, canceled live
+                case 'order.canceled':
+                case 'order.cancelled':
+                    $success = $this->_cancelOrder($data);
+                    break;
 
-            case 'payment_term.accepted':
-                $success = $this->_paymentTermAccepted($data);
-                break;
-        }
+                case 'payment_term.accepted':
+                    $success = $this->_paymentTermAccepted($data);
+                    break;
+            }
 
-        if ($success) {
-            http_response_code(200);
-        } else {
-            http_response_code(404);
+            if ($success) {
+                http_response_code(200);
+            } else {
+                http_response_code(404);
+            }
+        } catch (\Exception $e) {
+            $this->_logger->debug("Got an exception while processing a webhook: " . $e->getMessage());
+            throw $e;
         }
     }
 

--- a/Controller/updateOrderStatus/Index.php
+++ b/Controller/updateOrderStatus/Index.php
@@ -178,20 +178,22 @@ class Index extends \Magento\Framework\App\Action\Action
 
     protected function _paymentTermAccepted($data)
     {
-        $this->_logger->debug('apruve_paymentTermAccepted');
+        $apruve_order_token = $data->entity->id;
+        $magento_order_increment_id = $data->entity->merchant_order_id;
+        $this->_logger->debug("apruve_paymentTermAccepted webhook called for apruve order $apruve_order_token with magento increment $magento_order_increment_id");
 
         try {
             $this->order->loadByIncrementId($data->entity->merchant_order_id);
             if ($this->order->getEntityId() == null) {
-                $this->_logger->info("Cannot find this entity in Magento2 - possible duplicate webhook - paymentTermAccepted - MerchantOrderId: {$data->entity->merchant_order_id}");
+                $this->_logger->debug("Cannot find this entity in Magento2 - possible duplicate webhook - paymentTermAccepted - MerchantOrderId: {$data->entity->merchant_order_id}");
                 return true; // Quietly die and return a 200 code
             }
             $this->order->setStatus('apruve_buyer_approved');
             return $this->order->save();
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
-            $this->_logger->info("Cannot find this entity in Magento2 - possible duplicate webhook - paymentTermAccepted - MerchantOrderId: {$data->entity->merchant_order_id}");
+            $this->_logger->debug("Cannot find this entity in Magento2 - possible duplicate webhook - paymentTermAccepted - MerchantOrderId: {$data->entity->merchant_order_id}");
         } catch (\Exception $e) {
-            $this->_logger->info('Caught exception: ', $e->getMessage(), "\n");
+            $this->_logger->debug('Caught exception: ', $e->getMessage(), "\n");
             return false;
         }
         return true;

--- a/Controller/updateOrderStatus/Index.php
+++ b/Controller/updateOrderStatus/Index.php
@@ -154,8 +154,13 @@ class Index extends \Magento\Framework\App\Action\Action
 
             $this->invoice->loadByIncrementId($magento_invoice_increment_id);
             $this->_logger->debug('Loaded invoice via increment id: ' . $magento_invoice_increment_id);
-            $this->invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
-            $this->_logger->debug('Invoice payment status updated, saving');
+            if ($this->invoice->canCapture()) {
+                $this->_logger->debug('Invoice can be captured. Capturing');
+                $this->invoice->capture();
+                $this->_logger->debug('Captured');
+            } else {
+                $this->_logger->debug("ERROR: Invoice $magento_invoice_increment_id cannot be captured in response to apruve funding webhook");
+            }
             return $this->transaction->addObject($this->invoice)->save();
 
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {

--- a/Controller/updateOrderStatus/Index.php
+++ b/Controller/updateOrderStatus/Index.php
@@ -2,7 +2,7 @@
 
 namespace Apruve\Payment\Controller\updateOrderStatus;
 
-class Index extends \Magento\Framework\App\Action\Action
+class Index extends CSRFAwareAction
 {
     protected $order;
     protected $payments;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -30,7 +30,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Customer\Model\CustomerFactory $customerFactory,
         \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository,
         \Magento\Sales\Model\Service\OrderService $orderService,
-        \Magento\Payment\Helper\Data $paymentHelper
+        \Magento\Payment\Helper\Data $paymentHelper,
+        \Psr\Log\LoggerInterface $logger //log injection
     ) {
         $this->_storeManager      = $storeManager;
         $this->_product           = $product;
@@ -41,6 +42,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->customerRepository = $customerRepository;
         $this->orderService       = $orderService;
         $this->paymentHelper      = $paymentHelper;
+        $this->_logger = $logger;
 
         $this->method = $paymentHelper->getMethodInstance(self::CODE);
         parent::__construct($context);
@@ -204,5 +206,37 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getStoreUrl()
     {
         return $this->_storeManager->getStore()->getBaseUrl();
+    }
+
+    public function runApruveGetRequest($url) {
+        $this->_logger->debug("Running a GET against $url");
+        $curl = curl_init();
+        curl_setopt_array($curl, [
+            CURLOPT_URL            => $url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_ENCODING       => '',
+            CURLOPT_MAXREDIRS      => 10,
+            CURLOPT_TIMEOUT        => 30,
+            CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
+            CURLOPT_CUSTOMREQUEST  => 'GET',
+            CURLOPT_HTTPHEADER     => [
+                'accept: application/json',
+                'apruve-api-key: ' . $this->getApiKey(),
+                'content-type: application/json'
+            ]
+        ]);
+        $response   = curl_exec($curl);
+        $httpStatus = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        $error      = curl_error($curl);
+        curl_close($curl);
+        $this->_logger->debug("Got a response with status code $httpStatus");
+        if ($error) {
+            $parsed = json_decode($response);
+            throw new \Magento\Framework\Exception\LocalizedException(__('Bad Response from Apruve:' . $parsed->error));
+        }
+        if ($httpStatus == 200 || $httpStatus == 201) {
+            return json_decode($response);
+        }
+        return false;
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -206,7 +206,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->_storeManager->getStore()->getBaseUrl();
     }
 
-    public function runApruveGetRequest($url) {
+    public function runApruveGetRequest($url)
+    {
         $this->_logger->debug("Running a GET against $url");
         $curl = curl_init();
         curl_setopt_array($curl, [

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -30,8 +30,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Customer\Model\CustomerFactory $customerFactory,
         \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository,
         \Magento\Sales\Model\Service\OrderService $orderService,
-        \Magento\Payment\Helper\Data $paymentHelper,
-        \Psr\Log\LoggerInterface $logger //log injection
+        \Magento\Payment\Helper\Data $paymentHelper
     ) {
         $this->_storeManager      = $storeManager;
         $this->_product           = $product;
@@ -42,7 +41,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->customerRepository = $customerRepository;
         $this->orderService       = $orderService;
         $this->paymentHelper      = $paymentHelper;
-        $this->_logger = $logger;
 
         $this->method = $paymentHelper->getMethodInstance(self::CODE);
         parent::__construct($context);

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -2,6 +2,8 @@
 
 namespace Apruve\Payment\Model;
 
+use Magento\Directory\Helper\Data as DirectoryHelper;
+
 class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
 {
     const CODE = 'apruve';
@@ -27,6 +29,27 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
     protected $_token = null;
     protected $_order = null;
     protected $_order_data = null;
+    private $_logger;
+
+    // Make our own constructor so that we can inject a logger that we understand, rather than the weird magento wrapper one
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory,
+        \Magento\Framework\Api\AttributeValueFactory $customAttributeFactory,
+        \Magento\Payment\Helper\Data $paymentData,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Payment\Model\Method\Logger $parentLogger, // We want a different type of logger that we understand
+        \Psr\Log\LoggerInterface $logger, // This is our logger
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $data = [],
+        DirectoryHelper $directory = null)
+    {
+        $this->_logger = $logger;
+        parent::__construct($context, $registry, $extensionFactory, $customAttributeFactory, $paymentData, $scopeConfig, $parentLogger, $resource, $resourceCollection, $data, $directory);
+
+    }
 
     public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = null)
     {
@@ -49,10 +72,13 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
 
     public function authorize(\Magento\Payment\Model\InfoInterface $payment, $amount)
     {
+        $this->_logger->debug("PaymentMethod::authorize called");
         $info = $this->getInfoInstance();
         $token = $info->getAdditionalInformation()['aid'];
 
         if (!empty($token)) {
+            $this->_logger->debug("Authorizing an online order");
+            // It's an online order, so it has already been created on the apruve side by the checkout js. We just need to finalize it.
             $response = $this->_apruve(self::AUTHORIZE_ACTION, $token);
             if (!isset($response->id)) {
                 throw new \Magento\Framework\Validator\Exception(__('Payment authorize error.'));
@@ -66,8 +92,12 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
                 $this->_updateMerchantID($token, $order->getIncrementId());
             }
         } else {
+            // It's an offline order, so apruve has never heard of it.
+            $this->_logger->debug("Authorizing an offline order");
+            // Next two methods build the json we're going to send to apruve and put it in $this->_order_data
             $this->generate_order_data($payment, $amount);
             $this->generate_offline_order_data($payment, $amount);
+            $this->_logger->debug("Built an offline order, about to submit it");
             $response = $this->_apruve(self::OFFLINE_ACTION, $this->_token, json_encode($this->_order_data));
             if (!isset($response->id)) {
                 throw new \Magento\Framework\Validator\Exception(__('Offline order creation error.'));
@@ -79,6 +109,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
 
     public function validate()
     {
+        $this->_logger->debug("PaymentMethod::validate called");
         $info = $this->getInfoInstance();
         $token = $info->getAdditionalInformation()['aid'];
         if (!isset($token)) {
@@ -90,6 +121,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
 
     protected function _isAdmin($store = null)
     {
+        $this->_logger->debug("PaymentMethod::_isAdmin called");
         /** @var \Magento\Framework\ObjectManagerInterface $om */
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
         /** @var \Magento\Framework\App\State $state */
@@ -100,16 +132,18 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
 
     public function capture(\Magento\Payment\Model\InfoInterface $payment, $amount)
     {
-        $this->generate_order_data($payment, $amount, false);
-
-        $response = $this->_apruve(self::CAPTURE_ACTION, $payment->getParentTransactionId(), json_encode($this->_order_data));
-        if (!isset($response->id)) {
-            throw new \Magento\Framework\Validator\Exception(__('Invoice creation error.'));
-        }
-
-        $payment
-            ->setAmount($amount)
-            ->setTransactionId($response->id);
+        $this->_logger->debug("PaymentMethod::capture called, doing nothing");
+        // We used to make an invoice here, but I think that's wrong. We should be doing that in the shipment observer instead
+//        $this->generate_order_data($payment, $amount, false);
+//
+//        $response = $this->_apruve(self::CAPTURE_ACTION, $payment->getParentTransactionId(), json_encode($this->_order_data));
+//        if (!isset($response->id)) {
+//            throw new \Magento\Framework\Validator\Exception(__('Invoice creation error.'));
+//        }
+//
+//        $payment
+//            ->setAmount($amount)
+//            ->setTransactionId($response->id);
         return $this;
     }
 
@@ -128,6 +162,9 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
 
     protected function generate_order_data(\Magento\Payment\Model\InfoInterface $payment, $amount, $newOrder = true)
     {
+        // Fills in the _order_data associative array with data corresponding to either an apruve order or an apurve invoice
+        // If $newOrder is true then makes an order, if $newOrder is false then makes an invoice
+        // TODO: split the two use cases
         /**Validate*/
         if ($amount <= 0) {
             throw new \Magento\Framework\Validator\Exception(__('Invalid amount for capture.'));
@@ -249,6 +286,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
             $url = sprintf($url . "/%s", $action);
         }
 
+        $this->_logger->debug("PaymentMethod::_apruve called. Sending $requestType to $url");
         $curl = curl_init();
 
         curl_setopt_array($curl, [
@@ -277,9 +315,10 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
         }
 
         if ($httpStatus != 404) {
+            $this->_logger->debug("Got a good response with status code $httpStatus");
             return json_decode($response);
         }
-
+        $this->_logger->debug("Got a bad response with status code $httpStatus, throwing exception");
         throw new \Magento\Framework\Exception\LocalizedException('Could not complete operation with object ' . json_decode($response));
     }
 

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -39,12 +39,14 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
         \Magento\Framework\Api\AttributeValueFactory $customAttributeFactory,
         \Magento\Payment\Helper\Data $paymentData,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Payment\Model\Method\Logger $parentLogger, // We want a different type of logger that we understand
+        \Magento\Payment\Model\Method\Logger $parentLogger,
+        // We want a different type of logger that we understand
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = [],
-        DirectoryHelper $directory = null)
-    {
+        DirectoryHelper $directory = null
+    ) {
+    
         // A logger already exists somewhere in the class hierarchy but I can't find it so I'm forcing a new reference
         $this->_logger = \Magento\Framework\App\ObjectManager::getInstance()->get('\Psr\Log\LoggerInterface');
         parent::__construct($context, $registry, $extensionFactory, $customAttributeFactory, $paymentData, $scopeConfig, $parentLogger, $resource, $resourceCollection, $data);
@@ -87,7 +89,8 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
 
             // If Reserved Order ID is not correct
             $order = $payment->getOrder();
-            if($response->merchant_order_id != $order->getIncrementId()); {
+            if ($response->merchant_order_id != $order->getIncrementId()) {
+            } {
                 $this->_updateMerchantID($token, $order->getIncrementId());
             }
         } else {
@@ -181,8 +184,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
         $this->_order_data['shipping_cents'] = $this->_order->getData('shipping_amount') * 100;
         $this->_order_data['tax_cents'] = $this->_order->getData('tax_amount') * 100;
         $this->_order_data['merchant_notes'] = '';
-        if($newOrder)
-        {
+        if ($newOrder) {
             $this->_order_data['order_items'] = [];
             $this->_order_data['invoice_on_create'] = 'false';
         } else {
@@ -216,14 +218,11 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
             $lineItem['vendor'] = '';
             $lineItem['view_product_url'] = $product->getProductUrl();
 
-            if($newOrder)
-            {
+            if ($newOrder) {
                 $this->_order_data['order_items'][] = $lineItem;
-            } else
-            {
+            } else {
                 $this->_order_data['invoice_items'][] = $lineItem;
             }
-
         }
 
         /**Add Discount Item*/
@@ -242,11 +241,9 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
             $discountItem['vendor'] = '';
             $discountItem['view_product_url'] = $helper->getStoreUrl();
 
-            if($newOrder)
-            {
+            if ($newOrder) {
                 $this->_order_data['order_items'][] = $discountItem;
-            } else
-            {
+            } else {
                 $this->_order_data['invoice_items'][] = $discountItem;
             }
         }

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -40,15 +40,14 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
         \Magento\Payment\Helper\Data $paymentData,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Payment\Model\Method\Logger $parentLogger, // We want a different type of logger that we understand
-        \Psr\Log\LoggerInterface $logger, // This is our logger
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = [],
         DirectoryHelper $directory = null)
     {
-        $this->_logger = $logger;
-        parent::__construct($context, $registry, $extensionFactory, $customAttributeFactory, $paymentData, $scopeConfig, $parentLogger, $resource, $resourceCollection, $data, $directory);
-
+        // A logger already exists somewhere in the class hierarchy but I can't find it so I'm forcing a new reference
+        $this->_logger = \Magento\Framework\App\ObjectManager::getInstance()->get('\Psr\Log\LoggerInterface');
+        parent::__construct($context, $registry, $extensionFactory, $customAttributeFactory, $paymentData, $scopeConfig, $parentLogger, $resource, $resourceCollection, $data);
     }
 
     public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = null)

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -29,7 +29,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
     protected $_token = null;
     protected $_order = null;
     protected $_order_data = null;
-    private $_logger;
+    protected $_logger;
 
     // Make our own constructor so that we can inject a logger that we understand, rather than the weird magento wrapper one
     public function __construct(

--- a/Observer/ShipmentObserver.php
+++ b/Observer/ShipmentObserver.php
@@ -133,13 +133,13 @@ class ShipmentObserver implements ObserverInterface
         if (empty($token)) {
             throw new \Magento\Framework\Validator\Exception(__('Token empty'));
         }
-        if(!$this->_order->getId()) {
+        if (!$this->_order->getId()) {
             throw new \Magento\Framework\Validator\Exception(__('_order->getId() is falsey'));
         }
-        if($this->_order->getPayment()->getMethod() != self::CODE) {
-            throw new \Magento\Framework\Validator\Exception(__('Payment method wrong: ' . $this->_order->getPayment()->getMethod() ));
+        if ($this->_order->getPayment()->getMethod() != self::CODE) {
+            throw new \Magento\Framework\Validator\Exception(__('Payment method wrong: ' . $this->_order->getPayment()->getMethod()));
         }
-        if(!$this->_order->canInvoice()) {
+        if (!$this->_order->canInvoice()) {
             throw new \Magento\Framework\Validator\Exception(__('Cannot invoice. (Did you manually create an invoice in Magento?)'));
         }
 

--- a/Observer/ShipmentObserver.php
+++ b/Observer/ShipmentObserver.php
@@ -207,6 +207,13 @@ class ShipmentObserver implements ObserverInterface
         /* latest shipment comment */
         // $comment = $this->_getInvoiceComment($invoice);
 
+        $magento_invoice_id = $invoice->getIncrementId();
+        $this->_logger->debug("Preparing to create an apruve invoice from magento invoice $magento_invoice_id");
+
+        if (! isset($magento_invoice_id) || $magento_invoice_id == null) {
+            $this->_logger->debug("ERROR - No magento invoice id for this invoice yet, it will be lost when it is sent to apruve!");
+        }
+
         /* prepare invoice data */
         $data = json_encode([
             'invoice' => [
@@ -215,7 +222,7 @@ class ShipmentObserver implements ObserverInterface
                 'shipping_cents'      => $this->convertPrice($invoice->getBaseShippingAmount()),
                 'tax_cents'           => $this->convertPrice($invoice->getBaseTaxAmount()),
                 // 'merchant_notes' => $comment->getComment(),
-                'merchant_invoice_id' => $invoice->getIncrementId(),
+                'merchant_invoice_id' => $magento_invoice_id,
                 'invoice_items'       => $items,
                 'issue_on_create'     => true
             ]

--- a/Observer/ShipmentObserver.php
+++ b/Observer/ShipmentObserver.php
@@ -148,6 +148,8 @@ class ShipmentObserver implements ObserverInterface
                 // Create invoice
                 $invoice = $this->_invoiceService->prepareInvoice($this->_order, $itemQty);
                 $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
+                $invoice->register();
+                $invoice->save(); // Need to save now so we will have an invoice id to send to apruve
 
                 $data = $this->_getInvoiceData($invoice);
 
@@ -157,9 +159,6 @@ class ShipmentObserver implements ObserverInterface
                     throw new \Magento\Framework\Validator\Exception(__('Apruve invoice creation error.'));
                 }
                 $invoice->setTransactionId($response->id); // Apruve invoice id gets set on the invoice, and vice versa
-
-
-                $invoice->register();
 
                 $transactionSave = $this->_transaction->addObject(
                     $invoice

--- a/Observer/ShipmentObserver.php
+++ b/Observer/ShipmentObserver.php
@@ -26,7 +26,8 @@ class ShipmentObserver implements ObserverInterface
         \Magento\Framework\DB\Transaction $transaction,
         \Magento\Sales\Model\Service\InvoiceService $invoiceService,
         \Magento\Sales\Api\Data\OrderInterface $order,
-        \Magento\Sales\Api\Data\InvoiceInterface $invoiceInterface
+        \Magento\Sales\Api\Data\InvoiceInterface $invoiceInterface,
+        \Psr\Log\LoggerInterface $logger
     ) {
         $this->method            = $paymentHelper->getMethodInstance(self::CODE);
         $this->_helper           = $helper;
@@ -34,10 +35,12 @@ class ShipmentObserver implements ObserverInterface
         $this->_transaction      = $transaction;
         $this->_order            = $order;
         $this->_invoiceInterface = $invoiceInterface;
+        $this->_logger = $logger;
     }
 
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
+        $this->_logger->debug('Executing shipment observer');
         $this->_shipment = $observer->getEvent()->getShipment();
         $this->_order    = $this->_shipment->getOrder();
         $payment = $this->_order->getPayment();

--- a/Observer/ShipmentObserver.php
+++ b/Observer/ShipmentObserver.php
@@ -410,6 +410,8 @@ class ShipmentObserver implements ObserverInterface
         if (! empty($action)) {
             $url = sprintf($url . "/%s", $action);
         }
+
+        $this->_logger->debug("ShipmentObserver::_apruve called. Sending $requestType to $url");
         $curl = curl_init();
         curl_setopt_array($curl, [
             CURLOPT_URL            => $url,
@@ -430,6 +432,7 @@ class ShipmentObserver implements ObserverInterface
         $httpStatus = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $error      = curl_error($curl);
         curl_close($curl);
+        $this->_logger->debug("Got a response with status code $httpStatus");
         if ($error) {
             $parsed = json_decode($response);
             throw new \Magento\Framework\Exception\LocalizedException(__('Bad Response from Apruve:' . $parsed->error));

--- a/Observer/ShipmentObserver.php
+++ b/Observer/ShipmentObserver.php
@@ -147,7 +147,8 @@ class ShipmentObserver implements ObserverInterface
             if (!empty($token) && $this->_order->getId() && $this->_order->getPayment()->getMethod() == self::CODE && $this->_order->canInvoice()) {
                 // Create invoice
                 $invoice = $this->_invoiceService->prepareInvoice($this->_order, $itemQty);
-                $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
+                // Will be captured when there's a funding event
+                $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::NOT_CAPTURE);
                 $invoice->register();
                 $invoice->save(); // Need to save now so we will have an invoice id to send to apruve
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "MPL-2.0"
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1"
+    "php": "~7.1"
   },
   "support": {
     "email": "support@apruve.com",

--- a/view/frontend/web/js/view/payment/apruve.js
+++ b/view/frontend/web/js/view/payment/apruve.js
@@ -12,7 +12,7 @@ define([
         var url = window.checkoutConfig.payment.apruve.hash_reload;
         var order = window.checkoutConfig.payment.apruve.order;
 
-        if(typeof order !== "string") {
+        if (typeof order !== "string") {
             order = JSON.stringify(order);
         }
 


### PR DESCRIPTION
This branch kind of got away from me as I found and fixed issues and just kept adding them.

It fixes:
 - Duplicate order creation in apruve (one of which failed)
 - Captuing of payment at the wrong time (on invoice creation instead of funding)
 - Bad lookup of invoices / orders in magento
 - Setting apruve merchant_invoice_id as null because the magento id wasn't created yet
 - other stuff I can't think of.

The happy path of online and offline order creation should work at this point.